### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/config/model-binding.php
+++ b/config/model-binding.php
@@ -209,5 +209,21 @@ return [
         return NextDeveloper\Golf\Database\Models\GolfClub::findByRef($value);
 },
 
+'golfteetime' => function ($value) {
+        return NextDeveloper\Golf\Database\Models\GolfTeeTime::findByRef($value);
+},
+
+'golfreservation' => function ($value) {
+        return NextDeveloper\Golf\Database\Models\GolfReservation::findByRef($value);
+},
+
+'golfcourse' => function ($value) {
+        return NextDeveloper\Golf\Database\Models\GolfCourse::findByRef($value);
+},
+
+'golfclub' => function ($value) {
+        return NextDeveloper\Golf\Database\Models\GolfClub::findByRef($value);
+},
+
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 ];

--- a/src/Database/Filters/ClubsQueryFilter.php
+++ b/src/Database/Filters/ClubsQueryFilter.php
@@ -91,4 +91,5 @@ class ClubsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n\n\n\n\n
+
 }

--- a/src/Database/Filters/CoursesQueryFilter.php
+++ b/src/Database/Filters/CoursesQueryFilter.php
@@ -77,4 +77,5 @@ class CoursesQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n
+
 }

--- a/src/Database/Filters/ReservationsQueryFilter.php
+++ b/src/Database/Filters/ReservationsQueryFilter.php
@@ -85,4 +85,5 @@ class ReservationsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n
+
 }

--- a/src/Database/Filters/TeeTimesQueryFilter.php
+++ b/src/Database/Filters/TeeTimesQueryFilter.php
@@ -18,6 +18,58 @@ class TeeTimesQueryFilter extends AbstractQueryFilter
      */
     protected $builder;
 
+    public function golfer1($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
+        }
+
+        return $this->builder->where('golfer1', $operator, $value);
+    }
+
+    public function golfer2($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
+        }
+
+        return $this->builder->where('golfer2', $operator, $value);
+    }
+
+    public function golfer3($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
+        }
+
+        return $this->builder->where('golfer3', $operator, $value);
+    }
+
+    public function golfer4($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
+        }
+
+        return $this->builder->where('golfer4', $operator, $value);
+    }
+
     public function teeTimeStart($date)
     {
         return $this->builder->where('tee_time', '>=', $date);
@@ -77,4 +129,5 @@ class TeeTimesQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n
+
 }

--- a/src/Database/Models/Clubs.php
+++ b/src/Database/Models/Clubs.php
@@ -165,4 +165,5 @@ class Clubs extends Model
 
 
 
+
 }

--- a/src/Database/Models/Courses.php
+++ b/src/Database/Models/Courses.php
@@ -163,4 +163,5 @@ class Courses extends Model
 
 
 
+
 }

--- a/src/Database/Models/Reservations.php
+++ b/src/Database/Models/Reservations.php
@@ -160,4 +160,5 @@ class Reservations extends Model
 
 
 
+
 }

--- a/src/Database/Models/TeeTimes.php
+++ b/src/Database/Models/TeeTimes.php
@@ -24,6 +24,10 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property \Carbon\Carbon $deleted_at
+ * @property integer $golfer1
+ * @property integer $golfer2
+ * @property integer $golfer3
+ * @property integer $golfer4
  */
 class TeeTimes extends Model
 {
@@ -44,12 +48,12 @@ class TeeTimes extends Model
     protected $fillable = [
             'tee_time',
             'features',
-        'golfer1',
-        'golfer2',
-        'golfer3',
-        'golfer4',
             'golf_club_id',
             'golf_course_id',
+            'golfer1',
+            'golfer2',
+            'golfer3',
+            'golfer4',
     ];
 
     /**
@@ -80,6 +84,10 @@ class TeeTimes extends Model
     'created_at' => 'datetime',
     'updated_at' => 'datetime',
     'deleted_at' => 'datetime',
+    'golfer1' => 'integer',
+    'golfer2' => 'integer',
+    'golfer3' => 'integer',
+    'golfer4' => 'integer',
     ];
 
     /**
@@ -142,6 +150,7 @@ class TeeTimes extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Requests/TeeTimes/TeeTimesCreateRequest.php
+++ b/src/Http/Requests/TeeTimes/TeeTimesCreateRequest.php
@@ -17,11 +17,12 @@ class TeeTimesCreateRequest extends AbstractFormRequest
         'features' => 'nullable',
         'golf_club_id' => 'nullable|exists:golf_clubs,uuid|uuid',
         'golf_course_id' => 'nullable|exists:golf_courses,uuid|uuid',
-            'golfer1'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer2'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer3'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer4'   =>  'nullable|exists:crm_users,uuid|uuid',
+        'golfer1' => 'nullable|integer',
+        'golfer2' => 'nullable|integer',
+        'golfer3' => 'nullable|integer',
+        'golfer4' => 'nullable|integer',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 }

--- a/src/Http/Requests/TeeTimes/TeeTimesUpdateRequest.php
+++ b/src/Http/Requests/TeeTimes/TeeTimesUpdateRequest.php
@@ -17,11 +17,12 @@ class TeeTimesUpdateRequest extends AbstractFormRequest
         'features' => 'nullable',
         'golf_club_id' => 'nullable|exists:golf_clubs,uuid|uuid',
         'golf_course_id' => 'nullable|exists:golf_courses,uuid|uuid',
-            'golfer1'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer2'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer3'   =>  'nullable|exists:crm_users,uuid|uuid',
-            'golfer4'   =>  'nullable|exists:crm_users,uuid|uuid',
+        'golfer1' => 'nullable|integer',
+        'golfer2' => 'nullable|integer',
+        'golfer3' => 'nullable|integer',
+        'golfer4' => 'nullable|integer',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 }

--- a/src/Http/Transformers/AbstractTransformers/AbstractClubsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractClubsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Golf\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Golf\Database\Models\Clubs;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class ClubsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,16 +33,31 @@ class AbstractClubsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Clubs $model
      *
      * @return array
      */
     public function transform(Clubs $model)
     {
-                        $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                    $commonCityId = \NextDeveloper\Commons\Database\Models\Cities::where('id', $model->common_city_id)->first();
-        
+                                                $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                                                            $commonCityId = \NextDeveloper\Commons\Database\Models\Cities::where('id', $model->common_city_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -41,7 +75,91 @@ class AbstractClubsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Clubs $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Clubs $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Clubs $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Clubs $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Clubs $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Clubs $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Clubs $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Clubs $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Clubs $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractCoursesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractCoursesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Golf\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Golf\Database\Models\Courses;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class CoursesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractCoursesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Courses $model
      *
      * @return array
      */
     public function transform(Courses $model)
     {
-                        $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
-                    $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-        
+                                                $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
+                                                            $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -39,7 +73,91 @@ class AbstractCoursesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Courses $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Courses $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Courses $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Courses $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Courses $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Courses $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Courses $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Courses $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Courses $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractReservationsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractReservationsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Golf\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Golf\Database\Models\Reservations;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class ReservationsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,17 +33,32 @@ class AbstractReservationsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Reservations $model
      *
      * @return array
      */
     public function transform(Reservations $model)
     {
-                        $golfTeeTimeId = \NextDeveloper\Golf\Database\Models\TeeTimes::where('id', $model->golf_tee_time_id)->first();
-                    $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
-                    $golfCourseId = \NextDeveloper\Golf\Database\Models\Courses::where('id', $model->golf_course_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $golfTeeTimeId = \NextDeveloper\Golf\Database\Models\TeeTimes::where('id', $model->golf_tee_time_id)->first();
+                                                            $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
+                                                            $golfCourseId = \NextDeveloper\Golf\Database\Models\Courses::where('id', $model->golf_course_id)->first();
+                                                            $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -40,7 +74,91 @@ class AbstractReservationsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Reservations $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Reservations $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Reservations $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Reservations $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Reservations $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Reservations $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Reservations $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Reservations $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Reservations $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractTeeTimesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractTeeTimesTransformer.php
@@ -6,6 +6,24 @@ use GPBMetadata\Google\Api\Auth;
 use NextDeveloper\Golf\Database\Models\TeeTimes;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
 
 /**
  * Class TeeTimesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -16,100 +34,133 @@ class AbstractTeeTimesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param TeeTimes $model
      *
      * @return array
      */
     public function transform(TeeTimes $model)
     {
-        $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
-        $golfCourseId = \NextDeveloper\Golf\Database\Models\Courses::where('id', $model->golf_course_id)->first();
-
-        $golfer1 = null;
-
-        if ($model->golfer1) {
-            $golfer1 = \NextDeveloper\IAM\Database\Models\Users::withoutGlobalScope(AuthorizationScope::class)
-                ->where('id', $model->golfer1)
-                ->first();
-
-            $golfer1 = \NextDeveloper\CRM\Database\Models\Users::withoutGlobalScopes()
-                ->where('iam_user_id', $golfer1->id)
-                ->first();
-
-            if($golfer1) {
-                $golfer1 = $golfer1->uuid;
-            }
-        }
-
-        $golfer2 = null;
-
-        if ($model->golfer2) {
-            $golfer2 = \NextDeveloper\IAM\Database\Models\Users::withoutGlobalScope(AuthorizationScope::class)
-                ->where('id', $model->golfer2)
-                ->first();
-
-            $golfer2 = \NextDeveloper\CRM\Database\Models\Users::withoutGlobalScopes()
-                ->where('iam_user_id', $golfer2->id)
-                ->first();
-
-            if($golfer2) {
-                $golfer2 = $golfer2->uuid;
-            }
-        }
-
-        $golfer3 = null;
-
-        if ($model->golfer3) {
-            $golfer3 = \NextDeveloper\IAM\Database\Models\Users::withoutGlobalScope(AuthorizationScope::class)
-                ->where('id', $model->golfer3)
-                ->first();
-
-            $golfer3 = \NextDeveloper\CRM\Database\Models\Users::withoutGlobalScopes()
-                ->where('iam_user_id', $golfer3->id)
-                ->first();
-
-            if($golfer3) {
-                $golfer3 = $golfer3->uuid;
-            }
-        }
-
-        $golfer4 = null;
-
-        if ($model->golfer4) {
-            $golfer4 = \NextDeveloper\IAM\Database\Models\Users::withoutGlobalScope(AuthorizationScope::class)
-                ->where('id', $model->golfer4)
-                ->first();
-
-            $golfer4 = \NextDeveloper\CRM\Database\Models\Users::withoutGlobalScopes()
-                ->where('iam_user_id', $golfer4->id)
-                ->first();
-
-            if($golfer4) {
-                $golfer4 = $golfer4->uuid;
-            }
-        }
-
+                                                $golfClubId = \NextDeveloper\Golf\Database\Models\Clubs::where('id', $model->golf_club_id)->first();
+                                                            $golfCourseId = \NextDeveloper\Golf\Database\Models\Courses::where('id', $model->golf_course_id)->first();
+                        
         return $this->buildPayload(
             [
-                'id' => $model->uuid,
-                'tee_time' => $model->tee_time,
-                'features' => $model->features,
-                'golfer1'   => $golfer1,
-                'golfer2'   => $golfer2,
-                'golfer3'   => $golfer3,
-                'golfer4'   => $golfer4,
-                'golf_club_id' => $golfClubId ? $golfClubId->uuid : null,
-                'golf_course_id' => $golfCourseId ? $golfCourseId->uuid : null,
-                'golf_club_name'    =>  $golfClubId ? $golfClubId->name : null,
-                'golf_course_name'  =>  $golfCourseId ? $golfCourseId->name : null,
-                'created_at' => $model->created_at,
-                'updated_at' => $model->updated_at,
-                'deleted_at' => $model->deleted_at,
+            'id'  =>  $model->uuid,
+            'tee_time'  =>  $model->tee_time,
+            'features'  =>  $model->features,
+            'golf_club_id'  =>  $golfClubId ? $golfClubId->uuid : null,
+            'golf_course_id'  =>  $golfCourseId ? $golfCourseId->uuid : null,
+            'created_at'  =>  $model->created_at,
+            'updated_at'  =>  $model->updated_at,
+            'deleted_at'  =>  $model->deleted_at,
+            'golfer1'  =>  $model->golfer1,
+            'golfer2'  =>  $model->golfer2,
+            'golfer3'  =>  $model->golfer3,
+            'golfer4'  =>  $model->golfer4,
             ]
         );
     }
 
+    public function includeStates(TeeTimes $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(TeeTimes $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(TeeTimes $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(TeeTimes $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(TeeTimes $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(TeeTimes $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(TeeTimes $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(TeeTimes $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(TeeTimes $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE\n\n\n\n\n\n
+
 
 
 }

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -5,6 +5,7 @@ Route::prefix('golf')->group(
         Route::prefix('tee-times')->group(
             function () {
                 Route::get('/', 'TeeTimes\TeeTimesController@index');
+                Route::get('/actions', 'TeeTimes\TeeTimesController@getActions');
 
                 Route::get('{golf_tee_times}/tags ', 'TeeTimes\TeeTimesController@tags');
                 Route::post('{golf_tee_times}/tags ', 'TeeTimes\TeeTimesController@saveTags');
@@ -15,6 +16,8 @@ Route::prefix('golf')->group(
                 Route::get('/{golf_tee_times}', 'TeeTimes\TeeTimesController@show');
 
                 Route::post('/', 'TeeTimes\TeeTimesController@store');
+                Route::post('/{golf_tee_times}/do/{action}', 'TeeTimes\TeeTimesController@doAction');
+
                 Route::patch('/{golf_tee_times}', 'TeeTimes\TeeTimesController@update');
                 Route::delete('/{golf_tee_times}', 'TeeTimes\TeeTimesController@destroy');
             }
@@ -23,6 +26,7 @@ Route::prefix('golf')->group(
         Route::prefix('reservations')->group(
             function () {
                 Route::get('/', 'Reservations\ReservationsController@index');
+                Route::get('/actions', 'Reservations\ReservationsController@getActions');
 
                 Route::get('{golf_reservations}/tags ', 'Reservations\ReservationsController@tags');
                 Route::post('{golf_reservations}/tags ', 'Reservations\ReservationsController@saveTags');
@@ -33,6 +37,8 @@ Route::prefix('golf')->group(
                 Route::get('/{golf_reservations}', 'Reservations\ReservationsController@show');
 
                 Route::post('/', 'Reservations\ReservationsController@store');
+                Route::post('/{golf_reservations}/do/{action}', 'Reservations\ReservationsController@doAction');
+
                 Route::patch('/{golf_reservations}', 'Reservations\ReservationsController@update');
                 Route::delete('/{golf_reservations}', 'Reservations\ReservationsController@destroy');
             }
@@ -41,6 +47,7 @@ Route::prefix('golf')->group(
         Route::prefix('courses')->group(
             function () {
                 Route::get('/', 'Courses\CoursesController@index');
+                Route::get('/actions', 'Courses\CoursesController@getActions');
 
                 Route::get('{golf_courses}/tags ', 'Courses\CoursesController@tags');
                 Route::post('{golf_courses}/tags ', 'Courses\CoursesController@saveTags');
@@ -51,6 +58,8 @@ Route::prefix('golf')->group(
                 Route::get('/{golf_courses}', 'Courses\CoursesController@show');
 
                 Route::post('/', 'Courses\CoursesController@store');
+                Route::post('/{golf_courses}/do/{action}', 'Courses\CoursesController@doAction');
+
                 Route::patch('/{golf_courses}', 'Courses\CoursesController@update');
                 Route::delete('/{golf_courses}', 'Courses\CoursesController@destroy');
             }
@@ -59,6 +68,7 @@ Route::prefix('golf')->group(
         Route::prefix('clubs')->group(
             function () {
                 Route::get('/', 'Clubs\ClubsController@index');
+                Route::get('/actions', 'Clubs\ClubsController@getActions');
 
                 Route::get('{golf_clubs}/tags ', 'Clubs\ClubsController@tags');
                 Route::post('{golf_clubs}/tags ', 'Clubs\ClubsController@saveTags');
@@ -69,6 +79,8 @@ Route::prefix('golf')->group(
                 Route::get('/{golf_clubs}', 'Clubs\ClubsController@show');
 
                 Route::post('/', 'Clubs\ClubsController@store');
+                Route::post('/{golf_clubs}/do/{action}', 'Clubs\ClubsController@doAction');
+
                 Route::patch('/{golf_clubs}', 'Clubs\ClubsController@update');
                 Route::delete('/{golf_clubs}', 'Clubs\ClubsController@destroy');
             }
@@ -124,8 +136,13 @@ Route::prefix('golf')->group(
 
 
 
+
+
+
+
     }
 );
+
 
 
 

--- a/tests/Database/Models/GolfTeeTimeTestTraits.php
+++ b/tests/Database/Models/GolfTeeTimeTestTraits.php
@@ -58,6 +58,10 @@ trait GolfTeeTimeTestTraits
         $response = $this->http->request(
             'POST', '/golf/golfteetime', [
             'form_params'   =>  [
+                'golfer1'  =>  '1',
+                'golfer2'  =>  '1',
+                'golfer3'  =>  '1',
+                'golfer4'  =>  '1',
                     'tee_time'  =>  now(),
                             ],
                 ['http_errors' => false]
@@ -334,6 +338,82 @@ trait GolfTeeTimeTestTraits
             $model = \NextDeveloper\Golf\Database\Models\GolfTeeTime::first();
 
             event(new \NextDeveloper\Golf\Events\GolfTeeTime\GolfTeeTimeRestoredEvent($model));
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_golfteetime_event_golfer1_filter()
+    {
+        try {
+            $request = new Request(
+                [
+                'golfer1'  =>  '1'
+                ]
+            );
+
+            $filter = new GolfTeeTimeQueryFilter($request);
+
+            $model = \NextDeveloper\Golf\Database\Models\GolfTeeTime::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_golfteetime_event_golfer2_filter()
+    {
+        try {
+            $request = new Request(
+                [
+                'golfer2'  =>  '1'
+                ]
+            );
+
+            $filter = new GolfTeeTimeQueryFilter($request);
+
+            $model = \NextDeveloper\Golf\Database\Models\GolfTeeTime::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_golfteetime_event_golfer3_filter()
+    {
+        try {
+            $request = new Request(
+                [
+                'golfer3'  =>  '1'
+                ]
+            );
+
+            $filter = new GolfTeeTimeQueryFilter($request);
+
+            $model = \NextDeveloper\Golf\Database\Models\GolfTeeTime::filter($filter)->first();
+        } catch (\Exception $e) {
+            $this->assertFalse(false, $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+
+    public function test_golfteetime_event_golfer4_filter()
+    {
+        try {
+            $request = new Request(
+                [
+                'golfer4'  =>  '1'
+                ]
+            );
+
+            $filter = new GolfTeeTimeQueryFilter($request);
+
+            $model = \NextDeveloper\Golf\Database\Models\GolfTeeTime::filter($filter)->first();
         } catch (\Exception $e) {
             $this->assertFalse(false, $e->getMessage());
         }


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.